### PR TITLE
Configurable images

### DIFF
--- a/store/instagram-images.ts
+++ b/store/instagram-images.ts
@@ -40,7 +40,7 @@ export const instagramStore = {
         // query the api for banner images
         let url = config.images.baseUrl + 'instagram'
         const images = await getImages(url)
-        commit('SET_INSTAGRAM_IMAGES', images)
+        commit('SET_INSTAGRAM_IMAGES', images.instagramImages)
       } catch (err) {
         Logger.debug('Unable to load instagramImages' + err)()
       }

--- a/store/instagram-images.ts
+++ b/store/instagram-images.ts
@@ -7,7 +7,6 @@ export default interface InstagramImagesState {
 }
 
 const getImages = async (url): Promise<any> => {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
   try {
     const task = await TaskQueue.execute({ url,
       payload: {

--- a/store/promoted-offers.ts
+++ b/store/promoted-offers.ts
@@ -12,17 +12,17 @@ export default interface PromotedOffersState {
   headImage: any[]
 }
 
-const getImages = async(url): Promise<any> => {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED="0"
+const getImages = async (url): Promise<any> => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
   try {
     const task = await TaskQueue.execute({ url,
       payload: {
         method: 'GET',
         headers: {
-         'Content-Type': 'application/json',
+          'Content-Type': 'application/json'
         },
         mode: 'cors'
-      },
+      }
     })
     return task.result;
   } catch (err) {
@@ -48,12 +48,10 @@ export const promotedStore = {
     getHeadImage: state => state.headImage
   },
   actions: {
-    async updatePromotedOffers ({ commit, rootState }) {
-      let promotedBannersResource = rootState.storeView && rootState.storeView.storeCode ? `banners/${rootState.storeView.storeCode}_promoted_offers` : `promoted_offers`
+    async updatePromotedOffers ({ commit }) {
       try {
         // query the api for promoted images
-        console.log('storeview: ',rootState.storeView)
-        let url = config.images.baseUrl+"promoted"
+        let url = config.images.baseUrl + 'promoted'
         const images = await getImages(url)
         commit('updatePromotedOffers', images)
       } catch (err) {
@@ -63,7 +61,7 @@ export const promotedStore = {
     async updateHeadImage ({ commit }) {
       try {
         // query the api for banner images
-        let url = config.images.baseUrl+"head"
+        let url = config.images.baseUrl + 'head'
         const images = await getImages(url)
         commit('SET_HEAD_IMAGE', images.images)
       } catch (err) {

--- a/store/promoted-offers.ts
+++ b/store/promoted-offers.ts
@@ -1,4 +1,6 @@
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { TaskQueue } from '@vue-storefront/core/lib/sync'
+import config from 'config';
 
 export default interface PromotedOffersState {
   banners: {
@@ -8,6 +10,24 @@ export default interface PromotedOffersState {
     menuAsideBanners: any[]
   },
   headImage: any[]
+}
+
+const getImages = async(url): Promise<any> => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED="0"
+  try {
+    const task = await TaskQueue.execute({ url,
+      payload: {
+        method: 'GET',
+        headers: {
+         'Content-Type': 'application/json',
+        },
+        mode: 'cors'
+      },
+    })
+    return task.result;
+  } catch (err) {
+    console.error('error', err)
+  }
 }
 
 export const promotedStore = {
@@ -28,22 +48,24 @@ export const promotedStore = {
     getHeadImage: state => state.headImage
   },
   actions: {
-    async updatePromotedOffers ({ commit, rootState }, data) {
+    async updatePromotedOffers ({ commit, rootState }) {
       let promotedBannersResource = rootState.storeView && rootState.storeView.storeCode ? `banners/${rootState.storeView.storeCode}_promoted_offers` : `promoted_offers`
       try {
-        // Workaround to get jest --watch to work so don't change the import sting to a template string
-        const promotedOffersModule = await import(/* webpackChunkName: "vsf-promoted-offers-[request]" */ 'theme/resource/' + promotedBannersResource + '.json')
-        commit('updatePromotedOffers', promotedOffersModule)
+        // query the api for promoted images
+        console.log('storeview: ',rootState.storeView)
+        let url = config.images.baseUrl+"promoted"
+        const images = await getImages(url)
+        commit('updatePromotedOffers', images)
       } catch (err) {
         Logger.debug('Unable to load promotedOffers' + err)()
       }
     },
-    async updateHeadImage ({ commit, rootState }, data) {
-      let mainImageResource = rootState.storeView && rootState.storeView.storeCode ? `banners/${rootState.storeView.storeCode}_main-images` : `main-images`
+    async updateHeadImage ({ commit }) {
       try {
-        // Workaround to get jest --watch to work so don't change the import sting to a template string
-        const imageModule = await import(/* webpackChunkName: "vsf-head-img-[request]" */ 'theme/resource/' + mainImageResource + '.json')
-        commit('SET_HEAD_IMAGE', imageModule.images)
+        // query the api for banner images
+        let url = config.images.baseUrl+"head"
+        const images = await getImages(url)
+        commit('SET_HEAD_IMAGE', images.images)
       } catch (err) {
         Logger.debug('Unable to load headImage' + err)()
       }

--- a/store/promoted-offers.ts
+++ b/store/promoted-offers.ts
@@ -13,7 +13,6 @@ export default interface PromotedOffersState {
 }
 
 const getImages = async (url): Promise<any> => {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
   try {
     const task = await TaskQueue.execute({ url,
       payload: {


### PR DESCRIPTION
The frontpage now does an http request for the banner images, promoted images, and instagram images
![image](https://user-images.githubusercontent.com/17791285/113254315-3e5f5580-927b-11eb-8e7e-3f1279092329.png)
![image](https://user-images.githubusercontent.com/17791285/113254382-5931ca00-927b-11eb-910e-8127cd9f5a4c.png)
