### PR TITLE
url update for cookies

### DIFF
--- a/components/molecules/m-cookie-notification.vue
+++ b/components/molecules/m-cookie-notification.vue
@@ -4,13 +4,13 @@
       <div class="cookie">
         <div class="cookie__message">
           {{ message }}
-          <router-link
-            :to="detailsLink"
-            :title="detailsLinkText"
+          <a 
+            href="https://wiigo.cloud/en-US/privacy/cookie-policy"
+            target="_blank"
             class="cookie__message-link"
           >
             {{ detailsLinkText }}
-          </router-link>
+          </a>
         </div>
         <div class="cookie__icon">
           <SfIcon
@@ -34,10 +34,6 @@ export default {
     detailsLinkText: {
       type: String,
       default: i18n.t('See details')
-    },
-    detailsLink: {
-      type: String,
-      default: 'https://wiigo.cloud/en-US/privacy/cookie-policy'
     },
     message: {
       type: String,

--- a/components/molecules/m-cookie-notification.vue
+++ b/components/molecules/m-cookie-notification.vue
@@ -5,7 +5,7 @@
         <div class="cookie__message">
           {{ message }}
           <router-link
-            :to="localizedRoute(detailsLink)"
+            :to="detailsLink"
             :title="detailsLinkText"
             class="cookie__message-link"
           >
@@ -37,7 +37,7 @@ export default {
     },
     detailsLink: {
       type: String,
-      default: '/i/privacy'
+      default: 'https://wiigo.cloud/en-US/privacy/cookie-policy'
     },
     message: {
       type: String,

--- a/components/molecules/m-cookie-notification.vue
+++ b/components/molecules/m-cookie-notification.vue
@@ -37,7 +37,7 @@ export default {
     },
     detailsLink: {
       type: String,
-      default: '/privacy'
+      default: '/i/privacy'
     },
     message: {
       type: String,


### PR DESCRIPTION
the link on the cookies notice will link to the privacy policy will now open in a new page to the wiigo cookie policy